### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: /
+  schedule:
+    interval: daily
+  target-branch: master
+  labels:
+  - OPTIMADE-Client
+- package-ecosystem: gitsubmodule
+  directory: /
+  schedule:
+    interval: daily
+  target-branch: master
+  labels:
+  - Voilà template


### PR DESCRIPTION
This adds daily dependabot checks for the `voila-materialscloud-template` git submodule and the `requirements.txt` file, which only contains the `optimade-client` package.