### PR TITLE
Local testing | Update `optimade-client` | Use new `widget_ratio`

### DIFF
--- a/OPTIMADE-Client.ipynb
+++ b/OPTIMADE-Client.ipynb
@@ -31,7 +31,7 @@
     "from ipywidgets import dlink, GridspecLayout, HTML\n",
     "from IPython.display import display\n",
     "\n",
-    "selector = OptimadeQueryProviderWidget()\n",
+    "selector = OptimadeQueryProviderWidget(width_ratio=(38, 51))\n",
     "filters = OptimadeQueryFilterWidget(button_style='primary')\n",
     "summary = OptimadeSummaryWidget(direction='horizontal', button_style='info')\n",
     "\n",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-optimade-client[server]==2020.10.14
+optimade-client[server]==2020.10.26
 voila-materialscloud-template~=0.3.0

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+voila --Voila.config_file_paths=./ --no-browser --debug OPTIMADE-Client.ipynb


### PR DESCRIPTION
Update to the newly released `optimade-client` v2020.10.26, which adds `widget_ratio` and `widget_space` parameters to `OptimadeQueryProviderWidget`.
This is utilized to fix #15.

A `test.sh` script is added to test the notebook locally.