### PR TITLE
Use special branch install for template

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 optimade-client[server]==2021.1.25
-voila-materialscloud-template~=0.3.2
+-e git+https://github.com/materialscloud-org/voila-materialscloud-template.git@optimade_client#egg=voila-materialscloud-template


### PR DESCRIPTION
In order to mitigate the long loading time, a special branch has been
created in the `materialscloud-org/voila-materialscloud-template`
repository (`optimade_client`), which adds extra text for the loading
screen and removes the link form the Materials Cloud logo in the "Hosted
on" section.

Closes #30 