### PR TITLE
Minor optimization

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     name: Blacken
 
 - repo: https://gitlab.com/pycqa/flake8
-  rev: '3.8.4'
+  rev: '3.9.0'
   hooks:
   - id: flake8
     args: [--count, --show-source, --statistics]

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(TOP_DIR.joinpath("requirements_dev.txt")) as handle:
 
 setup(
     name="tools-optimade-client",
-    version="2021.3.11",
+    version="2021.3.16",
     license="MIT License",
     author="Casper Welzel Andersen",
     author_email="casper.andersen@epfl.ch",

--- a/tools_optimade_client/__init__.py
+++ b/tools_optimade_client/__init__.py
@@ -4,4 +4,4 @@ from .upload import QEInputButton
 __all__ = ("QEInputButton",)
 
 __author__ = "Casper Welzel Andersen"
-__version__ = "2021.3.11"
+__version__ = "2021.3.16"

--- a/tools_optimade_client/upload.py
+++ b/tools_optimade_client/upload.py
@@ -1,5 +1,4 @@
 """Upload to the Materials Cloud QE Input Generator tool"""
-import base64
 import tempfile
 from typing import Union
 import warnings
@@ -28,21 +27,7 @@ class QEInputButton(ipw.HTML):
     _button_format = """<button
     class="p-Widget jupyter-widgets jupyter-button widget-button mod-{button_style}"
     title="Use the chosen structure in the QE Input Generator Tool" style="width:auto;" {disabled}
-    onclick="var dataURI = 'data:charset={encoding};base64,{data}';
-// convert base64/URLEncoded data component to raw binary data held in a string
-var byteString;
-if (dataURI.split(',')[0].indexOf('base64') >= 0)
-    byteString = atob(dataURI.split(',')[1]);
-else
-    byteString = unescape(dataURI.split(',')[1]);
-
-// write the bytes of the string to a typed array
-var ia = new Uint8Array(byteString.length);
-for (var i = 0; i < byteString.length; i++) {{
-    ia[i] = byteString.charCodeAt(i);
-}}
-
-var file_data = new Blob([ia], {{type: 'charset={encoding}'}});
+    onclick="var file_data = new Blob([{data!r}], {{type: 'charset=utf-8'}});
 
 const XHR = new XMLHttpRequest();
 const FD = new FormData();
@@ -101,7 +86,6 @@ XHR.send(FD);">Use in QE Input Generator</button>
             button_style=self.style.value,
             data=kwargs.get("data", ""),
             disabled=kwargs.get("disabled", "disabled"),
-            encoding=kwargs.get("encoding", "utf-8"),
         )
 
     def format_button(self, disabled: bool = True, data: str = None) -> None:
@@ -158,11 +142,7 @@ XHR.send(FD);">Use in QE Input Generator</button>
 
         with tempfile.NamedTemporaryFile(mode="w+b") as handle:
             output.write(handle.name, format="xsf")
-            output = handle.read()
-
-        if isinstance(output, str):
-            output = output.encode("utf-8")
-        output = base64.b64encode(output).decode()
+            output = handle.read().decode("utf-8")
 
         self.format_button(disabled=False, data=output)
 


### PR DESCRIPTION
- This removes the en- and decoding using `base64`, directly passing the string (using `repr()`) as input to a JavaScript `Blob()`.
   Note that this is also more efficient in terms of bytesize, since the base64 data string would always be larger (longer) than the regular string.
- Update `flake8` in `pre-commit`.
- Bump version to `2021.3.16`.