### PR TITLE
CD to dev-dokku (matcloud.xyz)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   labels:
   - OPTIMADE-Client
 - package-ecosystem: github-actions
-  directory: "/"
+  directory: /
   schedule:
     interval: daily
   target-branch: master

--- a/.github/workflows/cd_dev-dokku.yml
+++ b/.github/workflows/cd_dev-dokku.yml
@@ -30,6 +30,7 @@ jobs:
       with:
         key: ${{ secrets.SSH_POST_FORWARDING_KEY }}
         name: id_rsa
+        known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
 
     - name: Deploy to dev-dokku
       run: |

--- a/.github/workflows/cd_dev-dokku.yml
+++ b/.github/workflows/cd_dev-dokku.yml
@@ -13,9 +13,21 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
+      with:
+        fetch-depth: '0'
 
-    - name: Setup dev-dokku remote
+    - name: Install SSH key for dev-dokku
+      uses: shimataro/ssh-key-action@v2
+      with:
+        key: ${{ secrets.SSH_DEPLOY_KEY }}
+        name: id_rsa_optimadeclient
+        known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
+        config: ${{ secrets.SSH_CONFIG }}
+
+    - name: Deploy to dev-dokku
       run: |
         git remote add dev-dokku dokku@matcloud.xyz:optimadeclient
-        git fetch --all -tp
-
+        git config --global user.email "casper.andersen@epfl.ch"
+        git config --global user.name "Casper Welzel Andersen"
+        git checkout master
+        git push dev-dokku master

--- a/.github/workflows/cd_dev-dokku.yml
+++ b/.github/workflows/cd_dev-dokku.yml
@@ -25,6 +25,7 @@ jobs:
         known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
         config: ${{ secrets.SSH_CONFIG }}
 
+
     - name: Deploy to dev-dokku
       run: |
         git remote add dev-dokku dokku@matcloud.xyz:optimadeclient

--- a/.github/workflows/cd_dev-dokku.yml
+++ b/.github/workflows/cd_dev-dokku.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - close_19_CD-to-dev-dokku
 
 jobs:
   deploy:

--- a/.github/workflows/cd_dev-dokku.yml
+++ b/.github/workflows/cd_dev-dokku.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - close_19_CD-to-dev-dokku
 
 jobs:
   deploy:

--- a/.github/workflows/cd_dev-dokku.yml
+++ b/.github/workflows/cd_dev-dokku.yml
@@ -25,6 +25,11 @@ jobs:
         known_hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
         config: ${{ secrets.SSH_CONFIG }}
 
+    - name: Install SSH key for host forwarding
+      uses: shimataro/ssh-key-action@v2
+      with:
+        key: ${{ secrets.SSH_POST_FORWARDING_KEY }}
+        name: id_rsa
 
     - name: Deploy to dev-dokku
       run: |

--- a/.github/workflows/cd_dev-dokku.yml
+++ b/.github/workflows/cd_dev-dokku.yml
@@ -1,0 +1,21 @@
+name: CD to dev-dokku
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: github.repository == 'materialscloud-org/tools-optimade-client'
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Setup dev-dokku remote
+      run: |
+        git remote add dev-dokku dokku@matcloud.xyz:optimadeclient
+        git fetch --all -tp
+


### PR DESCRIPTION
Closes #19.

Whenever a push is performed to `master`, it will be pushed to `dev-dokku` aka. matcloud.xyz.
One still has to manually push to `dokku` (production server).