### PR TITLE
Update GH actions + pre-commit

### DIFF
--- a/.github/workflows/cd_dev-dokku.yml
+++ b/.github/workflows/cd_dev-dokku.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v2.3.4
       with:
         fetch-depth: '0'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: [3.7, 3.8, 3.9]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.3.4
 
     - name: Set up Python ${{ matrix.python-version}}
       uses: actions/setup-python@v2
@@ -49,7 +49,7 @@ jobs:
         - ${{ github.workspace }}:/tmp/app
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.3.4
 
     - name: Test build with herokuish
       run: /bin/herokuish test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ repos:
     exclude: README.md
 
 - repo: https://github.com/ambv/black
-  rev: 21.4b0
+  rev: 21.5b1
   hooks:
   - id: black
     name: Blacken
 
 - repo: https://gitlab.com/pycqa/flake8
-  rev: '3.9.1'
+  rev: '3.9.2'
   hooks:
   - id: flake8
     args: [--count, --show-source, --statistics]


### PR DESCRIPTION
Update GH actions according to @dependabot.

Update pre-commit hooks `black` and `flake8`.
No files updated after running the updated pre-commit.