### PR TITLE
Pinning the ipywidgets-extended version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 optimade-client[server]==2022.6.9
+ipywidgets-extended==1.1.1
 voila-materialscloud-template>=0.3.6,<1
 -e .


### PR DESCRIPTION
It seems still the has issue with https://github.com/CasperWA/voila-optimade-client/issues/437, although we have pinning the `ipywidgets-extended==1.1.1`. 
I just pinned the version at this repository and it should work around the bug.