### PR TITLE
Clean up database provider list of MC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .ipynb_checkpoints/
 *.log
+*.pyc

--- a/OPTIMADE-Client.ipynb
+++ b/OPTIMADE-Client.ipynb
@@ -48,7 +48,7 @@
     "database_grouping = {\n",
     "    \"Materials Cloud\": {\n",
     "        \"Main Projects\": [\"mc3d-structures\", \"2dstructures\"],\n",
-    "        \"Contribution Projects\": [\n",
+    "        \"Contributed Projects\": [\n",
     "            \"2dtopo\",\n",
     "            \"pyrene-mofs\",\n",
     "            \"scdm\",\n",
@@ -119,25 +119,11 @@
     "display(selector, filters, summary)\n",
     "display(qe_input_generator_button)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/OPTIMADE-Client.ipynb
+++ b/OPTIMADE-Client.ipynb
@@ -44,20 +44,18 @@
     "    \"necro\",\n",
     "    \"jarvis\",\n",
     "]\n",
-    "skip_databases = {\"Materials Cloud\": [\"optimade-sample\", \"li-ion-conductors\", \"threedd\"]}\n",
+    "skip_databases = {\"Materials Cloud\": [\"optimade-sample\", \"li-ion-conductors\", \"threedd\", \"sssp\"]}\n",
     "database_grouping = {\n",
     "    \"Materials Cloud\": {\n",
-    "        \"General\": [\"curated-cofs\"],\n",
-    "        \"Projects\": [\n",
-    "            \"2dstructures\",\n",
+    "        \"Main Projects\": [\"mc3d-structures\", \"2dstructures\"],\n",
+    "        \"Contribution Projects\": [\n",
     "            \"2dtopo\",\n",
     "            \"pyrene-mofs\",\n",
     "            \"scdm\",\n",
-    "            \"sssp\",\n",
     "            \"stoceriaitf\",\n",
     "            \"tc-applicability\",\n",
-    "            \"mc3d-structures\",\n",
     "            \"tin-antimony-sulfoiodide\",\n",
+    "            \"curated-cofs\",\n",
     "        ]}\n",
     "}\n",
     "\n",
@@ -121,11 +119,25 @@
     "display(selector, filters, summary)\n",
     "display(qe_input_generator_button)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
According to Nicola, he wants to have MC3D and MC2D on the main list.
I also change the name of subgroup 'General' -> 'Main Projects' and 'Projects' -> 'Contribution Projects'.
Any idea what is the more proper name for the list? pinning @giovannipizzi, @csadorf @eimrek @CasperWA for comment about the name. 