### PR TITLE
Template change to materialscloud-tool

### DIFF
--- a/voila.json
+++ b/voila.json
@@ -8,7 +8,7 @@
   },
   "VoilaConfiguration": {
     "enable_nbextensions": true,
-    "template": "materialscloud-iframe",
+    "template": "materialscloud-tool",
     "strip_sources": true,
     "preheat_kernel": true
   },


### PR DESCRIPTION
Use the `materialscloud-tool` template so the plausible work. Before this merge, we need to make the optimate client tool in materials cloud `work/tools` redirect to the tool page instead of using iframe.